### PR TITLE
Getting rid of RN 0.25 warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,5 @@
-import React from 'react-native';
-
-const {
-  TextInput: {
-    State: TextInputState,
-  },
-} = React;
+import { TextInput } from 'react-native';
+const { State: TextInputState } = TextInput;
 
 export default function dismissKeyboard() {
   TextInputState.blurTextInput(TextInputState.currentlyFocusedField());


### PR DESCRIPTION
Get rid of the warning associated RN 0.25 which decrements the wrapping of React.